### PR TITLE
restore compatibility with node v4 and v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 const lib = require("./dist");
 
-module.exports = (...args) => lib.makeOptionalRequire(...args);
+module.exports = function() { return lib.makeOptionalRequire.apply(lib, arguments); }
 
 module.exports.tryRequire = lib.tryRequire;
 module.exports.tryResolve = lib.tryResolve;


### PR DESCRIPTION
https://github.com/jchip/optional-require/commit/15a25fcda4432071fa2f2a374122587e05aab027#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346 broke compatibility with Node.js 4 and 5, because Node 4 doesn't support spread operator. If this change is intentionally backwards breaking, it should be in a 2.0.0 release.