### PR TITLE
fix default parameter syntax breakage in Node.js v4

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [4.x, 10.x, 12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "esModuleInterop": true,
     "importHelpers": false,
-    "target": "ES2015",
+    "target": "ES5",
     "preserveConstEnums": true,
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
Hello,

The typescript compilation target along with the usage of default parameter values introduces a breakage on Node.js v4. The easiest fix seems to me to be to lower the TS target. I added node v4 to CI as well but that might not "just work". 

Please feel free to modify this PR directly if it helps move along the process of fixing, thanks for your time! 